### PR TITLE
Remove readme field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,5 @@ edition = "2018"
 description = "A simple object arena"
 repository = "https://github.com/smol-rs/vec-arena"
 documentation = "https://docs.rs/vec-arena"
-readme = "README.md"
 license = "Apache-2.0 OR MIT"
 categories = ["memory-management"]


### PR DESCRIPTION
Since 1.46, cargo can automatically detect the value of the readme field.