### PR TITLE
Deprecate in favor of slab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.2.0
+
+- **This crate is now deprecated in favor of [slab](https://crates.io/crates/slab).**
+
 # Version 1.1.0
 
 - Make the crate `#![no_std]`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,9 @@
 [package]
 name = "vec-arena"
-version = "1.1.0"
+# When publishing a new version:
+# - Update CHANGELOG.md
+# - Create "v1.x.y" git tag
+version = "1.2.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 description = "A simple object arena"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# vec-arena
+# vec-arena (deprecated)
 
 [![Build](https://github.com/smol-rs/vec-arena/workflows/Build%20and%20test/badge.svg)](
 https://github.com/smol-rs/vec-arena/actions)
 [![License](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](https://github.com/smol-rs/vec-arena)
 [![Cargo](https://img.shields.io/crates/v/vec-arena.svg)](https://crates.io/crates/vec-arena)
 [![Documentation](https://docs.rs/vec-arena/badge.svg)](https://docs.rs/vec-arena)
+
+**This crate is now deprecated in favor of [slab](https://crates.io/crates/slab).**
 
 #### What is this?
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,10 @@
 #![no_std]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![deprecated(
+    since = "1.2.0",
+    note = "This crate is now deprecated in favor of [slab](https://crates.io/crates/slab)."
+)]
 
 extern crate alloc;
 


### PR DESCRIPTION
Based on the described in https://github.com/smol-rs/async-io/pull/60, deprecate this crate in favor of slab.

> slab provides similar functionality to vec-arena, but is [used much more widely in the ecosystem](https://crates.io/crates/slab/reverse_dependencies), has some additional useful methods, and is a bit more efficient as far as I know.
> 
> Also, this will reduce the dependencies when using this crate along with async-std, futures-util, hyper, etc (because they depend on slab).
> 
> Also, I'm considering deprecating vec-arena in favor of slab, because:
> 
> * slab is more powerful
> * [slab is widely used in the ecosystem](https://crates.io/crates/slab/reverse_dependencies)
> * [there are very few users of vec-arena](https://crates.io/crates/vec-arena/reverse_dependencies)
> * I currently maintain virtually both crates and it's not fun to maintain multiple crates with the same content. And I basically preferentially maintain slab, which is more widely used in the ecosystem.

cc @smol-rs/admins: Do you have any opposition? If not, I'll merge it 2 weeks later.